### PR TITLE
Handle exception when getting package metadata

### DIFF
--- a/ckanext/orgportals/helpers.py
+++ b/ckanext/orgportals/helpers.py
@@ -542,7 +542,17 @@ def popular_datasets(org_name, num=5):
 
 def get_package_metadata(package):
     """Return the metadata of a dataset"""
-    result = toolkit.get_action('package_show')(None, {'id': package.get('name'), 'include_tracking': True})
+    result = {}
+    try:
+        result = toolkit.get_action('package_show')(None, {'id': package.get('name'), 'include_tracking': True})
+    except Exception:
+        log.exception("Error in retrieving dataset metadata for %s", package)
+        package_metadata = package
+        package_metadata['tracking_summary'] = {
+            'total': 0,
+            'recent' 0
+        }
+        return package_metadata
     return result
 
 

--- a/ckanext/orgportals/helpers.py
+++ b/ckanext/orgportals/helpers.py
@@ -550,7 +550,7 @@ def get_package_metadata(package):
         package_metadata = package
         package_metadata['tracking_summary'] = {
             'total': 0,
-            'recent' 0
+            'recent': 0
         }
         return package_metadata
     return result

--- a/ckanext/orgportals/templates/portals/snippets/footer.html
+++ b/ckanext/orgportals/templates/portals/snippets/footer.html
@@ -9,13 +9,11 @@
   <div class="row">
 
     <div class="attribution">
-      <p>
-        <span id="footer-attribution-text">Powered by</span>
-        <div style="white-space:nowrap" id="footer-attribution-content">
-          <a class="hide-text" target="_blank" href="https://opengov.com/?utm_campaign=Footer-Product-OpenData&utm_source=OpenGov&utm_medium=product&utm_term=PO-OGOV-1274&utm_content=logo"><img src="/img/OpenGov_Logo.png" alt="OpenGov"></a>
-          <a class="hide-text" target="_blank" href="http://ckan.org"><img src="/img/ckan_logo_white.png" alt="CKAN"></a>
-        </div>
-      </p>
+      <span id="footer-attribution-text">Powered by</span>
+      <div style="white-space:nowrap" id="footer-attribution-content">
+        <a class="hide-text" target="_blank" href="https://opengov.com/?utm_campaign=Footer-Product-OpenData&utm_source=OpenGov&utm_medium=product&utm_term=PO-OGOV-1274&utm_content=logo"><img src="/img/OpenGov_Logo.png" alt="OpenGov"></a>
+        <a class="hide-text" target="_blank" href="http://ckan.org"><img src="/img/ckan_logo_white.png" alt="CKAN"></a>
+      </div>
     </div>
 
   </div>


### PR DESCRIPTION
## Description
Handle exception when getting package metadata for deleted datasets.
If the dataset doesn't exist we set a default tracking_summary since the template expects it be populated.