### PR TITLE
Update hero slider and make advanced search doc link optional

### DIFF
--- a/ckanext/orgportals/controllers/portals.py
+++ b/ckanext/orgportals/controllers/portals.py
@@ -24,11 +24,11 @@ class OrgportalsController(PackageController):
     def library_show(self, org_name, source):
         return utils.library_show(org_name, source)
 
-    def contentpage_show(self, org_name, source, page_name):
-        return utils.contentpage_show(org_name, source, page_name)
+    def contentpage_show(self, org_name, page_name, source):
+        return utils.contentpage_show(org_name, page_name, source)
 
-    def custompage_show(self, org_name, source, page_name):
-        return utils.custompage_show(org_name, source, page_name)
+    def custompage_show(self, org_name, page_name, source):
+        return utils.custompage_show(org_name, page_name, source)
 
     def orgportals_subdashboards_index(self, org_name):
         return utils.orgportals_subdashboards_index(org_name)

--- a/ckanext/orgportals/fanstatic/hero.css
+++ b/ckanext/orgportals/fanstatic/hero.css
@@ -57,7 +57,7 @@ img {
 Main Components 
 -------------------------------- */
 .tint {
-  background-color: rgba(40,139,228,0.4);
+  background-color: rgba(1,1,1,0.5);
   position: absolute;
   height: 480px;
   width: 100%;
@@ -123,7 +123,7 @@ Main Components
   -o-transform: translateY(50px);
   transform: translateY(50px);
 }
-.cd-primary-nav a {
+.cd-primary-nav button {
   display: block;
   height: 50px;
   line-height: 50px;
@@ -160,7 +160,7 @@ Main Components
     display: inline-block;
     margin-left: 1em;
   }
-  .cd-primary-nav a {
+  .cd-primary-nav button {
     display: inline-block;
     height: auto;
     font-weight: 600;
@@ -175,6 +175,7 @@ Main Components
 Slider
 -------------------------------- */
 .cd-hero {
+  border-bottom: 2px solid #000000;
   position: relative;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -248,7 +249,6 @@ Slider
 }
 .icon-circle:before {
   content: "\f111";
-  font-size: 8px;
 }
 /* -------------------------------- 
 Single slide style
@@ -542,13 +542,12 @@ Slider navigation
   bottom: 0;
   z-index: 2;
   text-align: center;
-  height: 25px;
-  background-color: #1F549B;
+  height: 30px;
+  background-color: rgba(0, 0, 0, 0.5)
 }
-.cd-slider-nav nav, .cd-slider-nav ul, .cd-slider-nav li, .cd-slider-nav a {
+.cd-slider-nav nav, .cd-slider-nav ul, .cd-slider-nav li, .cd-slider-nav button {
   height: 100%;
   margin: 0;
-  padding: 0;
 }
 .cd-slider-nav nav {
   display: inline-block;
@@ -560,8 +559,8 @@ Slider navigation
   left: 0;
   width: 50px;
   height: 100%;
-  color: transparent;
-  background-color: transparent;
+  color: #d44457;
+  background-color: #ffffff;
   box-shadow: inset 0 2px 0 currentColor;
   -webkit-transition: -webkit-transform 0.2s, box-shadow 0.2s;
   -moz-transition: -moz-transform 0.2s, box-shadow 0.2s;
@@ -605,30 +604,34 @@ Slider navigation
   width: 50px;
   float: left;
 }
-.cd-slider-nav li.selected a {
-  color: #fbad23;
+.cd-slider-nav li.selected button {
+  color: #2c343b;
 }
-.no-touch .cd-slider-nav li.selected a:hover {
+.no-touch .cd-slider-nav li.selected button:hover {
   background-color: transparent;
 }
-.cd-slider-nav a {
+.cd-slider-nav button {
   display: block;
   position: relative;
-  padding-top: 5px;
   font-size: 1rem;
   font-weight: 700;
-  color: #ffffff;
+  color: #a8b4be;
   text-decoration: none;
   -webkit-transition: background-color 0.2s;
   -moz-transition: background-color 0.2s;
   transition: background-color 0.2s;
+  background-color: transparent;
+  border: none;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
 }
-.cd-slider-nav a::before {
+.cd-slider-nav button::before {
   content: '';
   position: absolute;
   width: 24px;
   height: 24px;
-  top: 0px;
+  top: 8px;
   left: 50%;
   right: auto;
   -webkit-transform: translateX(-50%);
@@ -637,51 +640,46 @@ Slider navigation
   -o-transform: translateX(-50%);
   transform: translateX(-50%);
 }
-.no-touch .cd-slider-nav a:hover {
-  background-color: rgba(0, 1, 1, 0.5);
+.no-touch .cd-slider-nav button:hover {
+  background-color: rgba(0, 1, 1, 0.6);
 }
-.cd-slider-nav li:first-of-type a::before {
+.cd-slider-nav li:first-of-type button::before {
   background-position: 0 0;
 }
-.cd-slider-nav li.selected:first-of-type a::before {
+.cd-slider-nav li.selected:first-of-type button::before {
   background-position: 0 -24px;
 }
-.cd-slider-nav li:nth-of-type(2) a::before {
+.cd-slider-nav li:nth-of-type(2) button::before {
   background-position: -24px 0;
 }
-.cd-slider-nav li.selected:nth-of-type(2) a::before {
+.cd-slider-nav li.selected:nth-of-type(2) button::before {
   background-position: -24px -24px;
 }
-.cd-slider-nav li:nth-of-type(3) a::before {
+.cd-slider-nav li:nth-of-type(3) button::before {
   background-position: -48px 0;
 }
-.cd-slider-nav li.selected:nth-of-type(3) a::before {
+.cd-slider-nav li.selected:nth-of-type(3) button::before {
   background-position: -48px -24px;
 }
-.cd-slider-nav li:nth-of-type(4) a::before {
+.cd-slider-nav li:nth-of-type(4) button::before {
   background-position: -72px 0;
 }
-.cd-slider-nav li.selected:nth-of-type(4) a::before {
+.cd-slider-nav li.selected:nth-of-type(4) button::before {
   background-position: -72px -24px;
 }
-.cd-slider-nav li:nth-of-type(5) a::before {
+.cd-slider-nav li:nth-of-type(5) button::before {
   background-position: -96px 0;
 }
-.cd-slider-nav li.selected:nth-of-type(5) a::before {
+.cd-slider-nav li.selected:nth-of-type(5) button::before {
   background-position: -96px -24px;
 }
 @media only screen and (min-width: 768px) {
-  .cd-slider-nav .cd-marker,
-  .cd-slider-nav li {
-    width: 65px;
-  }
-  .cd-slider-nav a {
-    padding-top: 5px;
+  .cd-slider-nav button {
     font-size: 1.1rem;
     text-transform: uppercase;
   }
-  .cd-slider-nav a::before {
-    top: 0;
+  .cd-slider-nav button::before {
+    top: 6px;
   }
 }
 

--- a/ckanext/orgportals/fanstatic/style.css
+++ b/ckanext/orgportals/fanstatic/style.css
@@ -1344,7 +1344,7 @@ a:focus {
 
 .carousel-inner > .item > a > img, .carousel-inner > .item > img, .img-responsive, .thumbnail a > img, .thumbnail > img {
     display: block;
-    max-width: 245px;
+    max-width: 250px;
     max-height: 80px;
 }
 
@@ -3338,6 +3338,9 @@ select[multiple].input-lg, textarea.input-lg {
 
 a {
     color: #165cab;
+}
+footer a, footer a:hover {
+    color: #ffffff;
 }
 .btn {
     display: inline-block;
@@ -7301,8 +7304,11 @@ header {
 .organization-logo {
     position: relative;
     float: left;
-    margin-right: 5px;
-    margin-left: 5px;
+}
+
+.organization-logo img {
+    max-width: 400px;
+    max-height: 100px;
 }
 
 @media (min-width: 600px) {
@@ -7562,12 +7568,6 @@ footer {
     background-color: #1F549B;
 }
 
-footer:before {
-    width: 100%;
-    height: 1px;
-    background-color: #fff
-}
-
 .copyright {
     margin-top: 16px;
 }
@@ -7700,7 +7700,7 @@ footer .container {
 
 .footer-container {
   /* margin-top: 70px; */
-  padding-bottom: 20px;
+  padding: 20px 30px;
 }
 
 .footer-container > .row {
@@ -8368,7 +8368,6 @@ ul.col-md-2 {
 .attribution {
   color: #FFFFFF;
   float: right;
-  padding-top: 20px;
 }
 
 .add-info {

--- a/ckanext/orgportals/helpers.py
+++ b/ckanext/orgportals/helpers.py
@@ -588,3 +588,15 @@ def get_default_resource_view(resource_id):
     except:
         log.debug("[orgportals] Error in retrieving resource view")
     return resource_view
+
+
+def search_document_page_exists(page_id):
+    try:
+        if not page_id:
+            return False
+        search_doc = toolkit.get_action('ckanext_pages_show')({},{'page': page_id})
+        if search_doc.get('content') and not search_doc.get('private'):
+            return True
+    except:
+        log.debug("[orgportals] Error in retrieving page")
+    return False

--- a/ckanext/orgportals/plugin/__init__.py
+++ b/ckanext/orgportals/plugin/__init__.py
@@ -152,6 +152,8 @@ class OrgportalsPlugin(MixinPlugin,
                 helpers.get_showcase_list,
             'orgportals_get_default_resource_view':
                 helpers.get_default_resource_view,
+            'orgportals_search_document_page_exists':
+                helpers.search_document_page_exists,
             'version': version_builder
         }
 

--- a/ckanext/orgportals/templates/portals/pages/home.html
+++ b/ckanext/orgportals/templates/portals/pages/home.html
@@ -1,5 +1,8 @@
 {% extends 'portals/index.html' %}
 
+{% set org = h.orgportals_get_current_organization(c.org_name) %}
+{% set org_display_name = org.title or c.org_name %}
+
 {% block toolbar %}
 {% endblock %}
 
@@ -12,7 +15,7 @@
     <div class="hero-content-container" style="background:url({{ image_url }}); background-size: cover; height:480px; z-index:-25">
       <div class="tint"></div>
       <div class="hero-content-container__content">
-        <h3 class="hero-content-container__header">{{ page.content_title or c.org_name}}</h3>
+        <h3 class="hero-content-container__header">{{ page.content_title or org_display_name}}</h3>
         <div class="hero-content-container__secondary">{{ h.render_markdown(page.text_box) }}</div>
       </div>
     </div>
@@ -27,11 +30,13 @@
       <div class="col-md-6">
         {% snippet 'portals/snippets/home/search.html' %}
       </div>
-      <p class="search-hint search-doc col-md-3">
-        <span>Try <a href="/pages/advanced-search-documentation"><u>Advanced Search Terms</u></a></span>
-        <br>
-        <span>for more specific results</span>
-      </p>
+      {% if h.orgportals_search_document_page_exists('advanced-search-documentation') %}
+        <p class="search-hint search-doc col-md-3">
+          <span>Try <a href="/pages/advanced-search-documentation" target="_blank"><u>Advanced Search Terms</u></a></span>
+          <br>
+          <span>for more specific results</span>
+        </p>
+      {% endif %}
     </div>
   </div>
   {% if h.orgportals_get_group_list(c.org_name) %}

--- a/ckanext/orgportals/templates/portals/snippets/all_data.html
+++ b/ckanext/orgportals/templates/portals/snippets/all_data.html
@@ -42,9 +42,11 @@
         </div>
       </div>
       <div class="data-block span9 responsive-panel">
-        <p class="search-doc">
-          <a href="/pages/advanced-search-documentation"><u>Advanced Search Terms</u></a>
-        </p>
+        {% if h.orgportals_search_document_page_exists('advanced-search-documentation') %}
+          <p class="search-doc">
+            <a href="/pages/advanced-search-documentation" target="_blank"><u>Advanced Search Terms</u></a>
+          </p>
+        {% endif %}
         {% snippet 'portals/snippets/search_form.html',
           form_id='dataset-search-form',
           type='dataset',

--- a/ckanext/orgportals/templates/portals/snippets/footer.html
+++ b/ckanext/orgportals/templates/portals/snippets/footer.html
@@ -7,6 +7,11 @@
 
 <footer class="footer-container" {# style="background: {{ base_color }}" #}>
   <div class="row">
+    <div class="col-md-2 col-lg-4">
+      <ul class="list-unstyled list-footer-nav">
+        <li><a href="/" title="{{ g.site_title }}" target="_blank">{{ g.site_title }}</a></li>
+      </ul>
+    </div>
 
     <div class="attribution">
       <span id="footer-attribution-text">Powered by</span>

--- a/ckanext/orgportals/templates/portals/snippets/header.html
+++ b/ckanext/orgportals/templates/portals/snippets/header.html
@@ -14,7 +14,6 @@
 {% set orgportals_show_portal_contentpage_route = 'orgportals_blueprint.show_portal_contentpage' if ckan_29_or_higher else 'orgportals_show_portal_contentpage' %}
 {% set orgportals_show_portal_custompage_route = 'orgportals_blueprint.show_portal_custompage' if ckan_29_or_higher else 'orgportals_show_portal_custompage' %}
 
-
 <header>
   {% snippet 'portals/snippets/language_switcher.html' %}
 
@@ -32,7 +31,7 @@
 
   <div class="row data-header-container">
     <div class="organization-logo">
-      <a href="{{ home_url }}" title="Home"><img class="img-responsive" src="{{ h.orgportals_get_organization_image(org_name) }}" alt="Organization logo"></a>
+      <a href="{{ home_url }}" title="{{ org_display_name }} Portal"><img src="{{ h.orgportals_get_organization_image(org_name) }}" alt="{{ org_display_name }} Logo"></a>
     </div>
 
     <div class="col-header-nav">
@@ -95,14 +94,6 @@
             {% endfor %}
           </ul>
         </div>
-      </nav>
-    </div>
-    <div>
-      {% set org = h.orgportals_get_current_organization(org_name) %}
-      <nav class="top-navigation pull-right">
-        <ul class="list-inline">
-          <li><a href="/" target='_blank'>{{ _('CNRA Open Data Home') }}</a></li>
-        </ul>
       </nav>
     </div>
   </div>

--- a/ckanext/orgportals/templates/portals/snippets/home/hero_slider.html
+++ b/ckanext/orgportals/templates/portals/snippets/home/hero_slider.html
@@ -15,7 +15,7 @@
   <ul class="cd-hero-slider autoplay">
     {% set hero_images_list = [image_url, image_url_2, image_url_3] %}
     {% for hero_img in hero_images_list %}
-      <li style="background-image: url({{hero_img}})" {%if loop.index == 1%}class="selected"{%endif%}>
+      <li style="background-image: url({{hero_img}})" {% if loop.index == 1 %}class="selected"{% endif %}>
         <div class="cd-full-width">
         </div> <!-- .cd-full-width -->
       </li>
@@ -24,9 +24,12 @@
   <div class="cd-slider-nav">
     <nav>
       <span class="cd-marker item-1"></span>
-      <ul>
+      <ul class="list-unstyled">
         {% for hero_img in hero_images_list %}
-          <li {%if loop.index == 1%}class="selected"{%endif%}><a href="#0"><i class="icon-circle"></i></a></li>
+          {% set current_loop_index = loop.index %}
+          <li {% if current_loop_index == 1 %}class="selected"{% endif %}>
+            <button aria-label="Change slider background to option {{current_loop_index}}"><i class="icon-circle"></i></button>
+          </li>
         {% endfor %}
       </ul>
     </nav>


### PR DESCRIPTION
## Description
This PR makes the following changes:
- Update CSS for hero slider on org portal home page
- Change anchor tag to button in hero slider navigation to improve accessibility
- Hide advanced search doc link on home page and data page if it's not publicly available
- Move link for Open Data Home from header to footer
- Fix order of parameters in contentpage_show() and custompage_show()