### PR TITLE
Remove class from view portal button on org form

### DIFF
--- a/ckanext/orgportals/templates/organization/snippets/organization_form.html
+++ b/ckanext/orgportals/templates/organization/snippets/organization_form.html
@@ -91,7 +91,7 @@
 
       {% set source = 'admin' %}
 
-      <a class="btn btn-primary pull-right"
+      <a class="btn pull-right"
         target="_blank"
         href="{% url_for orgportals_view_portal_route,
                          locale=locale,


### PR DESCRIPTION
## Description
Remove `btn-primary` class from view portal button on organization form.