### PR TITLE
Remove view dataset button

### DIFF
--- a/ckanext/orgportals/fanstatic/style.css
+++ b/ckanext/orgportals/fanstatic/style.css
@@ -18,7 +18,7 @@ body {
 }
 
 .resources-title a {
-    color: #000;
+    color: #165cab;
 }
 
 body, figure {
@@ -1331,9 +1331,9 @@ a {
     text-decoration: none
 }
 
-a:focus, a:hover {
-    color: #000;
-    text-decoration: underline
+a:hover, a:focus {
+    color: #113845;
+    text-decoration: underline;
 }
 
 a:focus {
@@ -1406,8 +1406,8 @@ select[multiple], select[size], textarea.form-control {
 .h1, .h2, .h3, .h4, .h5, .h6, h1, h2, h3, h4, h5, h6 {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-weight: 700;
-    line-height: 1.5;
-    color: #375F87;
+    line-height: 1.1;
+    color: inherit;
 }
 
 .h1 .small, .h1 small, .h2 .small, .h2 small, .h3 .small, .h3 small, .h4 .small, .h4 small, .h5 .small, .h5 small, .h6 .small, .h6 small, h1 .small, h1 small, h2 .small, h2 small, h3 .small, h3 small, h4 .small, h4 small, h5 .small, h5 small, h6 .small, h6 small {
@@ -1469,6 +1469,8 @@ p {
 
 .data-set p {
     color: #131517;
+    position: relative;
+    z-index: 1;
 }
 
 .col-md-4 p {
@@ -3344,23 +3346,23 @@ footer a, footer a:hover {
 }
 .btn {
     display: inline-block;
-    padding: 4px 12px;
     margin-bottom: 0;
-    font-size: 14px;
-    line-height: 20px;
+    font-weight: normal;
     text-align: center;
+    white-space: nowrap;
     vertical-align: middle;
+    touch-action: manipulation;
     cursor: pointer;
-    color: #333333;
-    text-shadow: 0 1px 1px rgb(255 255 255 / 75%);
-    background-color: #f7f7f7;
-    border: 1px solid #cccccc;
-    border-bottom-color: #b3b3b3;
-    box-shadow: inset 0 1px 0 rgb(255 255 255 / 20%), 0 1px 2px rgb(0 0 0 / 5%);
+    background-image: none;
+    border: 1px solid transparent;
+    padding: 6px 12px;
+    font-size: 14px;
+    line-height: 1.42857143;
+    border-radius: 4px;
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
-    user-select: none
+    user-select: none;
 }
 
 .btn.active.focus, .btn.active:focus, .btn.focus, .btn:active.focus, .btn:active:focus, .btn:focus {
@@ -3393,9 +3395,9 @@ a.btn.disabled, fieldset[disabled] a.btn {
 }
 
 .btn-default {
-    color: #333;
-    background-color: #fff;
-    border-color: #ccc
+    background: rgb(247, 249, 250);
+    border: 1px solid rgb(181, 185, 189);
+    color: rgb(97, 99, 101);
 }
 
 .btn-default.focus, .btn-default:focus {
@@ -3440,8 +3442,8 @@ a.btn.disabled, fieldset[disabled] a.btn {
 
 .btn-primary.active, .btn-primary:active, .btn-primary:hover, .open > .dropdown-toggle.btn-primary {
     color: #fff;
-    background-color: #c60;
-    border-color: #c60;
+    background: rgb(4, 65, 135);
+    border: 1px solid rgb(97, 99, 101);
 }
 
 .btn-primary.active.focus, .btn-primary.active:focus, .btn-primary.active:hover, .btn-primary:active.focus, .btn-primary:active:focus, .btn-primary:active:hover, .open > .dropdown-toggle.btn-primary.focus, .open > .dropdown-toggle.btn-primary:focus, .open > .dropdown-toggle.btn-primary:hover {
@@ -4936,7 +4938,6 @@ select[multiple].input-group-sm > .form-control, select[multiple].input-group-sm
     color: #505050;
     font-weight: 500;
     font-size: 20px;
-    text-decoration: none;
 }
 
 .pagination {
@@ -7411,7 +7412,7 @@ main:after {
 }
 
 .data-block-heading {
-    margin-bottom: 16px
+    margin-bottom: 16px;
     color: #375F87;
 }
 /*
@@ -7434,14 +7435,9 @@ main:after {
 }
 
 .data-set-title {
-    margin-top: 0;
     font-size: 18px;
     font-weight: 700;
     padding-left: 0px;
-}
-
-.data-set a {
-    color: #165cab;
 }
 
 @media (min-width: 343px) and (max-width: 376px) {
@@ -7628,7 +7624,6 @@ footer .container {
 }
 
 .resources-dropdown-name a {
-    /*text-decoration: underline;*/
     font-weight: bold;
 }
 
@@ -8873,6 +8868,8 @@ ul.unstyled, ol.unstyled {
 
 .dataset-actions {
   float: right;
+  position: relative;
+  z-index: 10;
 }
 .dataset-actions .view-dataset {
   padding-right: 20px;

--- a/ckanext/orgportals/templates/portals/snippets/show_datasets.html
+++ b/ckanext/orgportals/templates/portals/snippets/show_datasets.html
@@ -26,19 +26,15 @@ Example:
     <article class="data-set">
       <div class="row">
         <div class="col-md-12">
-          <h3 class="data-set-title col-md-8" onclick="toggleResources('{{ datasets_group_name }}-resources-{{ package.id }}'); return false;">
-            {{ h.markdown_extract(title, extract_length=truncate_title) }}
+          <h3 class="heading data-set-title col-md-8">
+            <a href="/dataset/{{package.name}}" aria-label="View dataset {{ title }}">
+              {{ h.markdown_extract(title, extract_length=truncate_title) }}
+            </a>
           </h3>
           <div class="dataset-actions">
-            <a href="/dataset/{{package.name}}"
-               target="_blank"
-               class="view-dataset"
-               aria-label="View dataset {{ title }}">
-              <i class="fa fa-desktop "></i> {{ _('View dataset') }}
-            </a>
             <button onclick="toggleResources('{{ datasets_group_name }}-resources-{{ package.id }}'); return false;"
-                    aria-label="Toggle between hiding and showing resources and additional information for {{ title }}"
-                    class="btn">
+                    aria-label="Toggle visibility of resources and additional information for {{ title }}"
+                    class="btn btn-default">
              <i class="fa fa-list-ul"></i>{{ _(' List resources') }}
             </button>
           </div>
@@ -98,8 +94,17 @@ Example:
                   {% endif %}
                 </div>
                 <div class="btn-group">
-                  <a href="{{ resource.url }}" class="btn btn-sm btn-primary" target="_blank"><i class="fa fa-arrow-circle-o-down"></i>{{ _(' Download')}}</a>
-                  <a href="{{ h.orgportals_get_resource_view_url(dataset=package.name, id=resource.id) }}" class="btn btn-sm btn-primary" target="_blank"><i class="fa fa-desktop "></i> {{ _('Preview') }}</a>
+                  {% if resource.url and resource.url_type == 'upload' %}
+                    <a href="{{ resource.url }}" class="btn btn-sm btn-primary resource-url-analytics" target="_blank" aria-label="Download resource {{ resource.name or resource.id }}">
+                      <i class="fa fa-arrow-circle-o-down"></i>
+                      {{ _(' Download')}}
+                    </a>
+                  {% else %}
+                    <a href="{{ resource.url }}" class="btn btn-sm btn-primary resource-url-analytics" target="_blank" aria-label="Go to resource {{ resource.name or resource.id }}">
+                      <i class="fa fa-external-link"></i>
+                      {{ _('Go to resource') }}
+                    </a>
+                  {% endif %}
                 </div>
               </div>
             </div>
@@ -115,7 +120,7 @@ Example:
         <div class="add-info-block">
           <div class="row">
             <div class="col-sm-12 col-md-12">
-              <h4>{{ _('Additional information') }}</h4>
+              <h4>{{ _('Additional Information') }}</h4>
             </div>
           </div>
 

--- a/ckanext/orgportals/templates/portals/snippets/show_pdfs.html
+++ b/ckanext/orgportals/templates/portals/snippets/show_pdfs.html
@@ -26,19 +26,15 @@ Example:
     <article class="data-set">
       <div class="row">
         <div class="col-md-12">
-          <h3 class="data-set-title col-md-8" onclick="toggleResources('{{ datasets_group_name }}-resources-{{ package.id }}'); return false;">
-            {{ h.markdown_extract(title, extract_length=truncate_title) }}
+          <h3 class="heading data-set-title col-md-8">
+            <a href="/dataset/{{package.name}}" aria-label="View dataset {{ title }}">
+              {{ h.markdown_extract(title, extract_length=truncate_title) }}
+            </a>
           </h3>
           <div class="dataset-actions">
-            <a href="/dataset/{{package.name}}"
-               target="_blank"
-               class="view-dataset"
-               aria-label="View document {{ title }}">
-              <i class="fa fa-desktop "></i> {{ _('View document') }}
-            </a>
             <button onclick="toggleResources('{{ datasets_group_name }}-resources-{{ package.id }}'); return false;"
-                    aria-label="Toggle between hiding and showing resources and additional information for {{ title }}"
-                    class="btn">
+                    aria-label="Toggle visibility of resources and additional information for {{ title }}"
+                    class="btn btn-default">
               <i class="fa fa-list-ul"></i>{{ _(' Toggle resources') }}
             </button>
           </div>
@@ -75,26 +71,34 @@ Example:
                   {% endif %}
                 </div>                
                 <div class="btn-group">
-                  <a href="{{ resource.url }}" class="btn btn-sm btn-primary res-download" target="_blank"><i class="fa fa-arrow-circle-o-down"></i>{{ _(' Download')}}</a>
+                  {% if resource.url and resource.url_type == 'upload' %}
+                    <a href="{{ resource.url }}" class="btn btn-sm btn-primary resource-url-analytics" target="_blank" aria-label="Download resource {{ resource.name or resource.id }}">
+                      <i class="fa fa-arrow-circle-o-down"></i>
+                      {{ _(' Download')}}
+                    </a>
+                  {% else %}
+                    <a href="{{ resource.url }}" class="btn btn-sm btn-primary resource-url-analytics" target="_blank" aria-label="Go to resource {{ resource.name or resource.id }}">
+                      <i class="fa fa-external-link"></i>
+                      {{ _('Go to resource') }}
+                    </a>
+                  {% endif %}
+                  {# Display PDF view #}
                   {% set resource_view = h.orgportals_get_default_resource_view(resource.id) %}
                   {% if resource_view %}
                   <button class="btn btn-sm btn-primary res-view" onclick="toggleResources('resource-view-{{ resource.id }}'); return false;">
                     <i class="fa fa-desktop "></i>{{ _(' View') }}
                   </button>
                   {% endif %}
-{#
-                  <a href="{{ h.orgportals_get_resource_view_url(dataset=package.name, id=resource.id) }}" class="btn btn-sm btn-primary" target="_blank"><i class="fa fa-desktop "></i> {{ _('Preview') }}</a>
-#}
                 </div>
                 {% if resource_view %}
-                <div class="resource-view hidden" id="resource-view-{{resource.id}}">
+                  <div class="resource-view hidden" id="resource-view-{{resource.id}}">
                     {% set src = h.url_for('resource_view', id=package.name,
-                                           resource_id=resource.id,
-                                           view_id=resource_view.id)  %}
+                                            resource_id=resource.id,
+                                            view_id=resource_view.id)  %}
                     <iframe src="{{ src }}" frameborder="0" width="100%" height="500px" data-module="data-viewer" allowfullscreen>
                       <p>{{ _('Your browser does not support iframes.') }}</p>
                     </iframe>
-                </div>
+                  </div>
                 {% endif %}
               </div>
             </div>
@@ -110,7 +114,7 @@ Example:
         <div class="add-info-block">
           <div class="row">
             <div class="col-sm-12 col-md-12">
-              <h4>{{ _('Additional information') }}</h4>
+              <h4>{{ _('Additional Information') }}</h4>
             </div>
           </div>
           {% if package.author %}


### PR DESCRIPTION
## Description

Remove view dataset button and make the dataset title a link.

Also make the following changes:
- Made dataset and resource titles clickable links
- Removed redundant “View dataset” and "Preview" links
- Show "Download" button for uploaded files and show "Go to resource" button for external links
- Updated link colors and hover styles to better identify clickable links